### PR TITLE
Fix expressions with multiple operators.

### DIFF
--- a/calculator/src/parser.rs
+++ b/calculator/src/parser.rs
@@ -48,8 +48,7 @@ fn build_ast_from_expr(pair: pest::iterators::Pair<Rule>) -> Node {
                     lhs = retval;
                     rhs = build_ast_from_term(pair.next().unwrap());
                     retval = parse_binary_expr(op, lhs, rhs);
-                }
-                else {
+                } else {
                     return retval;
                 }
             }
@@ -175,7 +174,7 @@ mod tests {
         test_expr("1 + 2 + 3 + 4", "1 + (2 + (3 + 4))");
         test_expr("1 + 2 + 3 - 4", "(1 + 2) + (3 - 4)");
     }
-    
+
     #[test]
     fn multiple_operators() {
         assert_eq!(

--- a/calculator/src/parser.rs
+++ b/calculator/src/parser.rs
@@ -182,12 +182,11 @@ mod tests {
             parse("1+2+3").unwrap(),
             vec![Node::BinaryExpr {
                 op: Operator::Plus,
-                lhs: Box::new(
-                    Node::BinaryExpr {
-                        op: Operator::Plus,
-                        lhs: Box::new(Node::Int(1)),
-                        rhs: Box::new(Node::Int(2)),}
-                        ),
+                lhs: Box::new(Node::BinaryExpr {
+                    op: Operator::Plus,
+                    lhs: Box::new(Node::Int(1)),
+                    rhs: Box::new(Node::Int(2)),
+                }),
                 rhs: Box::new(Node::Int(3)),
             }]
         )

--- a/calculator/src/parser.rs
+++ b/calculator/src/parser.rs
@@ -179,15 +179,16 @@ mod tests {
     #[test]
     fn multiple_operators() {
         assert_eq!(
-            parse("1+2"),
+            parse("1+2+3").unwrap(),
             vec![Node::BinaryExpr {
                 op: Operator::Plus,
-                lhs: Node::BinaryExpr {
-                    op: Operator::Plus,
-                    lhs: Node::Int(2),
-                    rhs: Node::Int(2),
-                },
-                rhs: Node::Int(3),
+                lhs: Box::new(
+                    Node::BinaryExpr {
+                        op: Operator::Plus,
+                        lhs: Box::new(Node::Int(1)),
+                        rhs: Box::new(Node::Int(2)),}
+                        ),
+                rhs: Box::new(Node::Int(3)),
             }]
         )
     }

--- a/calculator/src/parser.rs
+++ b/calculator/src/parser.rs
@@ -175,4 +175,20 @@ mod tests {
         test_expr("1 + 2 + 3 + 4", "1 + (2 + (3 + 4))");
         test_expr("1 + 2 + 3 - 4", "(1 + 2) + (3 - 4)");
     }
+    
+    #[test]
+    fn multiple_operators() {
+        assert_eq!(
+            parse("1+2"),
+            vec![Node::BinaryExpr {
+                op: Operator::Plus,
+                lhs: Node::BinaryExpr {
+                    op: Operator::Plus,
+                    lhs: Node::Int(2),
+                    rhs: Node::Int(2),
+                },
+                rhs: Node::Int(3),
+            }]
+        )
+    }
 }

--- a/calculator/src/parser.rs
+++ b/calculator/src/parser.rs
@@ -36,11 +36,23 @@ fn build_ast_from_expr(pair: pest::iterators::Pair<Rule>) -> Node {
         Rule::BinaryExpr => {
             let mut pair = pair.into_inner();
             let lhspair = pair.next().unwrap();
-            let lhs = build_ast_from_term(lhspair);
-            let op = pair.next().unwrap();
+            let mut lhs = build_ast_from_term(lhspair);
+            let mut op = pair.next().unwrap();
             let rhspair = pair.next().unwrap();
-            let rhs = build_ast_from_term(rhspair);
-            parse_binary_expr(op, lhs, rhs)
+            let mut rhs = build_ast_from_term(rhspair);
+            let mut retval = parse_binary_expr(op, lhs, rhs);
+            loop {
+                let pair_buf = pair.next();
+                if pair_buf != None {
+                    op = pair_buf.unwrap();
+                    lhs = retval;
+                    rhs = build_ast_from_term(pair.next().unwrap());
+                    retval = parse_binary_expr(op, lhs, rhs);
+                }
+                else {
+                    return retval;
+                }
+            }
         }
         unknown => panic!("Unknown expr: {:?}", unknown),
     }


### PR DESCRIPTION
Expressions such as ``1 +2;`` or ``300*200`` work, but expressions which have multiple operations do not work. For example: ``1+2+3+4`` does not work, and has to be put in a chain of parentheses to get it to work. The other valid expressions are getting evaluated to the value of the first operator, for instance, ``1*2*3`` becomes 2, by evaluating 1*2 and so on.
This can be solved by adding a loop, converting the first two expressions into ``lhs`` and continuing until there are no more ``pair``s.