### PR TITLE
Use features to describe LLVM wrapper instead of branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Make sure you have
 2. Cloned this repository (follow the instructions in each chapter)
 3. LLVM installed to run and test locally `cargo test --tests`
     * Easiest option is LLVM v10.0 ([Debian/Ubuntu](https://apt.llvm.org/) or [macOS](https://formulae.brew.sh/formula/llvm))
-    * Otherwise, in `Cargo.toml` you'd need to change the `inkwell = { ..., branch = "your-llvm-version" }` with LLVM version on your system (output of `llvm-config --version`)
+    * Otherwise, in `Cargo.toml` you'd need to change the `inkwell = { ..., features = ["your-llvm-version"] }` with LLVM version on your system (output of `llvm-config --version`)
 
 
 To build the book locally, navigate to the `book` subdirectory and follow the instructions in [mdbook](https://github.com/rust-lang/mdBook).

--- a/book/src/01_calculator/basic_llvm.md
+++ b/book/src/01_calculator/basic_llvm.md
@@ -3,10 +3,10 @@
 
 ### Setup
 
-The code is available in [`calculator/examples/llvm/src/main.rs`](https://github.com/ehsanmok/create-your-own-lang-with-rust/blob/master/calculator/examples/llvm/src/main.rs). Because my `llvm-config --version` shows `10.0.0` so I'm using `branch = "llvm=10-0"` in inkwell
+The code is available in [`calculator/examples/llvm/src/main.rs`](https://github.com/ehsanmok/create-your-own-lang-with-rust/blob/master/calculator/examples/llvm/src/main.rs). Because my `llvm-config --version` shows `10.0.0` so I'm using `features = ["llvm10-0"]` in inkwell
 
 ```text
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "llvm10-0" }
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm10-0"] }
 ```
 
 Go to [`calculator/examples/llvm`](https://github.com/ehsanmok/create-your-own-lang-with-rust/blob/master/calculator/examples/llvm/) sub-crate and `cargo run`.

--- a/calculator/Cargo.toml
+++ b/calculator/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 pest = "2.1"
 pest_derive = "2.1"
 anyhow = "1.0"
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "llvm10-0" }  # use branch according to your llvm version
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm10-0"] }  # use correct feature according to your llvm version
 rustyline = "6.2"
 cfg-if = "0.1"
 

--- a/calculator/src/compiler/jit.rs
+++ b/calculator/src/compiler/jit.rs
@@ -1,6 +1,6 @@
 use inkwell::{
     builder::Builder, context::Context, execution_engine::JitFunction, types::IntType,
-    values::IntValue, values::AnyValue, OptimizationLevel,
+    values::AnyValue, values::IntValue, OptimizationLevel,
 };
 
 use crate::{Compile, Node, Operator, Result};

--- a/calculator/src/compiler/jit.rs
+++ b/calculator/src/compiler/jit.rs
@@ -1,6 +1,6 @@
 use inkwell::{
     builder::Builder, context::Context, execution_engine::JitFunction, types::IntType,
-    values::IntValue, OptimizationLevel,
+    values::IntValue, values::AnyValue, OptimizationLevel,
 };
 
 use crate::{Compile, Node, Operator, Result};

--- a/calculator/src/compiler/jit.rs
+++ b/calculator/src/compiler/jit.rs
@@ -94,6 +94,7 @@ mod tests {
         assert_eq!(Jit::from_source("2 + (2 - 1)").unwrap(), 3);
         assert_eq!(Jit::from_source("(2 + 3) - 1").unwrap(), 4);
         assert_eq!(Jit::from_source("1 + ((2 + 3) - (2 + 3))").unwrap(), 1);
+        assert_eq!(Jit::from_source("(1 + 2)").unwrap(), 3);
         // parser fails
         // assert_eq!(Jit::from_source("2 + 3 - 1").unwrap(), 4);
     }

--- a/calculator/src/grammar.pest
+++ b/calculator/src/grammar.pest
@@ -1,12 +1,12 @@
 Program = _{ SOI ~ Expr ~ EOF }
 
-Expr = { UnaryExpr | BinaryExpr }
+Expr = { UnaryExpr | BinaryExpr | Term }
 
 Term = _{Int | "(" ~ Expr ~ ")" }
 
 UnaryExpr = { Operator ~ Term }
 
-BinaryExpr = { Term ~ (Operator ~ Term)* }
+BinaryExpr = { Term ~ (Operator ~ Term)+ }
 
 Operator = { "+" | "-" }
 


### PR DESCRIPTION
After reading the information on the [inkwell README](https://github.com/TheDan64/inkwell), we should be using features instead of branch names. Branch naming is sometimes chaotic and unreliable. Instead, use features and list the version of llvm you are using. There is a table under [inkwell's Usage](https://github.com/TheDan64/inkwell). The general scheme though is "llvm[major]-[minor]" and doesn't include patches.