### PR TITLE
Calculator support for constant value expressions

### DIFF
--- a/book/src/01_calculator/grammar_lexer_parser.md
+++ b/book/src/01_calculator/grammar_lexer_parser.md
@@ -33,7 +33,7 @@ Don't let this overwhelm you - let's break it down line by line:
 
 **`Expr = { UnaryExpr | BinaryExpr | Term }`** - An expression is either unary (`-1`), binary (`1 + 2`), or a simple term (just a number). The `|` means "or" - try each alternative in order.
 
-**`Term = _{ Int | "(" ~ Expr ~ ")" }`** - A term is either a number or a parenthesized expression. This is how we handle `(1 + 2) * 3` - the parenthesized part becomes a single term.
+**`Term = { Int | "(" ~ Expr ~ ")" }`** - A term is either a number or a parenthesized expression. This is how we handle `(1 + 2) * 3` - the parenthesized part becomes a single term.
 
 **`UnaryExpr = { Operator ~ Term }`** - A unary expression is an operator followed by a term, like `-1` or `+5`.
 

--- a/calculator/src/compiler/interpreter.rs
+++ b/calculator/src/compiler/interpreter.rs
@@ -57,6 +57,7 @@ mod tests {
 
     #[test]
     fn basics() {
+        assert_eq!(Interpreter::from_source("1").unwrap() as i32, 1);
         assert_eq!(Interpreter::from_source("1 + 2").unwrap() as i32, 3);
         // assert_eq!(Interpreter::source("(1 + 2)").unwrap() as i32, 3);
         assert_eq!(Interpreter::from_source("2 + (2 - 1)").unwrap() as i32, 3);

--- a/calculator/src/grammar.pest
+++ b/calculator/src/grammar.pest
@@ -2,7 +2,7 @@ Program = _{ SOI ~ Expr ~ EOF }
 
 Expr = { BinaryExpr | UnaryExpr | Term }
 
-Term = _{ Int | "(" ~ Expr ~ ")" }
+Term = { Int | "(" ~ Expr ~ ")" }
 
 UnaryExpr = { Operator ~ Term }
 

--- a/calculator/src/parser.rs
+++ b/calculator/src/parser.rs
@@ -62,11 +62,15 @@ fn build_ast_from_expr(pair: pest::iterators::Pair<Rule>) -> Node {
                 }
             }
         }
+        Rule::Term => build_ast_from_term(pair),
         unknown => panic!("Unknown expr: {:?}", unknown),
     }
 }
 
 fn build_ast_from_term(pair: pest::iterators::Pair<Rule>) -> Node {
+    assert_eq!(pair.as_rule(), Rule::Term);
+
+    let pair = pair.into_inner().next().unwrap();
     match pair.as_rule() {
         Rule::Int => {
             let int: i32 = pair.as_str().parse().unwrap();
@@ -106,6 +110,10 @@ mod tests {
     #[test]
     fn basics() {
         assert!(parse("b").is_err());
+
+        let one = parse("1");
+        assert!(one.is_ok());
+        assert_eq!(one.unwrap()[0], Node::Int(1));
     }
 
     #[test]


### PR DESCRIPTION
The grammar allows programs that evaluate constant value, but the parser does not handle it properly. The existing parser implementation didn't handle `~ Term` part of the language grammar because its definition was unfolded into `Int | Expr`.

I implemented the fix by removing `_` prefix to disable rule folding and handled `Term` rules explicitly. The alternative would be to handle `Int` case individually or introducing a new `Const` rule that defines `Int` (and `Float` as a part of the exercise) and handling it separately.